### PR TITLE
feat: switch npm registry by working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ The `dot_dotfiles_update` script is sourced by `.zshrc` and auto-runs `chezmoi u
 
 ## Structure
 
-- `dot_zshrc` — Main shell config. Loads all alias files from `~/.aliases/`, configures NVM, rbenv, Java, PostgreSQL PATH entries.
-- `dot_gitconfig` — Git settings with conditional includes: `~/.gitconfig-niji` for work projects, `~/.gitconfig-perso` for personal.
+- `dot_zshrc` — Main shell config. Sources a curated list of alias files from `~/.aliases/` (explicit `. ~/.aliases/<name>.sh` lines — not a glob), configures NVM, rbenv, Java, PostgreSQL PATH entries, plus bun integration.
+- `dot_gitconfig` — Git settings with `includeIf gitdir:` rules pointing at per-context configs in `~/Documents/projects/<group>/.gitconfig` (currently `niji/`, `personal/`, `kering/`). Each per-context file sets identity, signing key, and (for Kering) the GitHub URL rewrite to use the `github-kering` SSH host alias.
 - `dot_aliases/` — Modular alias/function files loaded in alphabetical order. `colors.sh` and `text.sh` must load before others (they define helpers used downstream).
 - `dot_vimrc` — Minimal vim config (syntax, 2-space indent, no backups).
 - `dot_gitignore_global` — Global git ignores.
@@ -34,7 +34,16 @@ Each file in `dot_aliases/` is a standalone shell script sourced by `.zshrc`. Ke
 - `rails.sh` — Foreman shortcuts (`fs`, `fsd`), Rails console/grep
 - `pg.sh` — PostgreSQL helpers: `resetdb`, `restoredb <file>`, `dumpdb`, `hedumpdb <app>` (Heroku)
 - `editor.sh` — `c` for Cursor IDE, `cc` for Claude Code, `note` for meeting notes
+- `npm.sh` — registers a `chpwd` hook that switches `NPM_CONFIG_USERCONFIG` to `~/.npmrcs/kering` when the working directory is under `~/Documents/projects/kering/`, and unsets it elsewhere
 - `zsh.sh` — `update` (Brew + dotfiles), `cleanup`, `reload`
+
+## npm registry per directory
+
+The default `~/.npmrc` points at the public npm registry (`registry.npmjs.org`). For Kering work, an alternative user-config lives at `~/.npmrcs/kering` and holds the Artifactory registry plus auth token (perms `600`, never committed).
+
+The `npm.sh` alias module exports `NPM_CONFIG_USERCONFIG=~/.npmrcs/kering` whenever the working directory is under `~/Documents/projects/kering/`, and unsets it elsewhere. The switch happens at every `cd` and at shell startup.
+
+Limitations: this only covers interactive zsh. A non-shell launch (IDE, CI) that does not inherit the env var will fall back to the public registry. For projects that need to enforce the Kering registry regardless of launch context, drop a per-repo `.npmrc` at the project root — it has higher precedence than the user-config.
 
 ## Git conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ The `dot_dotfiles_update` script is sourced by `.zshrc` and auto-runs `chezmoi u
 - `dot_zshrc` — Main shell config. Sources a curated list of alias files from `~/.aliases/` (explicit `. ~/.aliases/<name>.sh` lines — not a glob), configures NVM, rbenv, Java, PostgreSQL PATH entries, plus bun integration.
 - `dot_gitconfig` — Git settings with `includeIf gitdir:` rules pointing at per-context configs in `~/Documents/projects/<group>/.gitconfig` (currently `niji/`, `personal/`, `kering/`). Each per-context file sets identity, signing key, and (for Kering) the GitHub URL rewrite to use the `github-kering` SSH host alias.
 - `dot_aliases/` — Modular alias/function files loaded in alphabetical order. `colors.sh` and `text.sh` must load before others (they define helpers used downstream).
+- `dot_npmrcs/` — Example npm user-configs that the `npm.sh` hook can switch to. Only `*.example` files are tracked (real configs hold auth tokens and live un-tracked next to them, see "npm registry per directory").
 - `dot_vimrc` — Minimal vim config (syntax, 2-space indent, no backups).
 - `dot_gitignore_global` — Global git ignores.
 
@@ -44,6 +45,23 @@ The default `~/.npmrc` points at the public npm registry (`registry.npmjs.org`).
 The `npm.sh` alias module exports `NPM_CONFIG_USERCONFIG=~/.npmrcs/kering` whenever the working directory is under `~/Documents/projects/kering/`, and unsets it elsewhere. The switch happens at every `cd` and at shell startup.
 
 Limitations: this only covers interactive zsh. A non-shell launch (IDE, CI) that does not inherit the env var will fall back to the public registry. For projects that need to enforce the Kering registry regardless of launch context, drop a per-repo `.npmrc` at the project root — it has higher precedence than the user-config.
+
+### Setting up a fresh machine
+
+`~/.npmrcs/kering` contains an Artifactory auth token and is **never** committed to this repo. On a clean machine, after `chezmoi apply`:
+
+1. The hook is installed and active, but defensive: if `~/.npmrcs/kering` is missing it silently falls back to `~/.npmrc` (public). No ENOENT spam.
+2. To enable the Kering registry, materialize the example and paste the real token:
+
+   ```bash
+   cp ~/.npmrcs/kering.example ~/.npmrcs/kering
+   $EDITOR ~/.npmrcs/kering        # replace PASTE_YOUR_ARTIFACTORY_TOKEN_HERE
+   chmod 600 ~/.npmrcs/kering
+   ```
+
+3. Open a new shell (or `source ~/.zshrc`); `cd` into a `~/Documents/projects/kering/` repo and confirm with `npm config get registry` that you see the Artifactory URL.
+
+The token can be pulled from your password manager or another machine via a secure channel — do not commit it.
 
 ## Git conventions
 

--- a/dot_aliases/npm.sh
+++ b/dot_aliases/npm.sh
@@ -1,0 +1,20 @@
+# npm registry switch by working directory.
+# Mirrors the gitconfig includeIf pattern: when cwd is under the Kering
+# project tree, point npm at the Artifactory user-config; otherwise fall
+# back to ~/.npmrc (public registry).
+
+autoload -Uz add-zsh-hook
+
+function _npm_registry_chpwd () {
+  case "$PWD/" in
+    "$HOME/Documents/projects/kering/"*)
+      export NPM_CONFIG_USERCONFIG="$HOME/.npmrcs/kering"
+      ;;
+    *)
+      unset NPM_CONFIG_USERCONFIG
+      ;;
+  esac
+}
+
+add-zsh-hook chpwd _npm_registry_chpwd
+_npm_registry_chpwd   # initialize on shell start (chpwd does not fire then)

--- a/dot_aliases/npm.sh
+++ b/dot_aliases/npm.sh
@@ -8,7 +8,16 @@ autoload -Uz add-zsh-hook
 function _npm_registry_chpwd () {
   case "$PWD/" in
     "$HOME/Documents/projects/kering/"*)
-      export NPM_CONFIG_USERCONFIG="$HOME/.npmrcs/kering"
+      # Defensive: the kering profile holds an auth token and is not in the
+      # dotfiles repo. On a fresh machine it has to be created manually
+      # (see AGENTS.md, "Setting up a fresh machine"). Until then, fall
+      # back silently to ~/.npmrc rather than pointing npm at a missing
+      # user-config (which would log ENOENT on every command).
+      if [ -f "$HOME/.npmrcs/kering" ]; then
+        export NPM_CONFIG_USERCONFIG="$HOME/.npmrcs/kering"
+      else
+        unset NPM_CONFIG_USERCONFIG
+      fi
       ;;
     *)
       unset NPM_CONFIG_USERCONFIG

--- a/dot_npmrcs/kering.example
+++ b/dot_npmrcs/kering.example
@@ -1,0 +1,2 @@
+registry=https://artifactory.arsenal.mgmt4apps.io/artifactory/api/npm/keringtech-npm-eagle-custom-front-aws-master/
+//artifactory.arsenal.mgmt4apps.io/artifactory/api/npm/keringtech-npm-eagle-custom-front-aws-master/:_authToken=PASTE_YOUR_ARTIFACTORY_TOKEN_HERE

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -58,6 +58,7 @@ alias reload="source ~/.zshrc && cd -"
 . ~/.aliases/ip.sh
 . ~/.aliases/mongo.sh
 . ~/.aliases/node.sh
+. ~/.aliases/npm.sh
 . ~/.aliases/path.sh
 . ~/.aliases/pg.sh
 . ~/.aliases/rails.sh
@@ -78,3 +79,10 @@ if [ -f ~/.dotfiles_update ]; then
 fi
 
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
+
+# bun completions
+[ -s "/Users/romain.laurent/.bun/_bun" ] && source "/Users/romain.laurent/.bun/_bun"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"


### PR DESCRIPTION
## Summary

- Add a `chpwd` hook (`dot_aliases/npm.sh`) that switches the active npm user-config to `~/.npmrcs/kering` when the working directory is under `~/Documents/projects/kering/`, and falls back to `~/.npmrc` (public registry) elsewhere.
- Replace the user-level `~/.npmrc` symlink (which used to permanently point at the Kering profile) with a regular file targeting `registry.npmjs.org` (done locally on the machine, not in this PR).
- Wire the new alias module into `dot_zshrc` (the loader is an explicit list, not a glob).
- Absorb the pre-existing bun integration lines that had drifted into the live `~/.zshrc`, so `chezmoi apply` stays clean going forward.
- Mirror the existing `includeIf gitdir:` pattern of `~/.gitconfig`, so npm now follows the same per-directory contract as git.
- Drop the manual `deoxxa/npmrc` switcher (was only installed under node v22 and the user is on v24 — effectively dead).
- Fix obsolete dotfiles documentation that referenced `~/.gitconfig-niji` / `~/.gitconfig-perso` (those files do not exist; the real per-context configs live at `~/Documents/projects/<group>/.gitconfig`).
- Fix imprecise wording in `AGENTS.md` that suggested `dot_zshrc` loaded all `~/.aliases/*` via a glob — it actually uses an explicit curated list.

## Fresh-machine support

`~/.npmrcs/kering` holds an Artifactory auth token and is intentionally **not** committed. To make the dotfiles repo safe to clone on a new machine:

- The hook is now defensive: if `~/.npmrcs/kering` is missing it falls back silently to the public registry (no ENOENT spam).
- A committed template `dot_npmrcs/kering.example` provides the registry URL + a placeholder token. New machines: `cp ~/.npmrcs/kering.example ~/.npmrcs/kering`, paste the real token, `chmod 600`. Procedure documented in `AGENTS.md`.

## Test plan

- [x] `cd ~/Documents/projects/personal/agent-skills && npm config get registry` returns `https://registry.npmjs.org/`
- [x] `cd ~/Documents/projects/kering/<repo> && npm config get registry` returns the Artifactory URL
- [x] Opening a fresh terminal directly inside the Kering tree resolves to the Artifactory registry without manual `cd` (init call works)
- [x] No npm warnings about deprecated `email` / `always-auth` keys when running `npm config` outside the Kering tree
- [x] `nvm use 22 && which npmrc` is empty (deoxxa/npmrc cleanly uninstalled)
- [x] Defensive fallback verified: temporarily renaming `~/.npmrcs/kering` makes the Kering tree resolve to the public registry silently, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)