### PR TITLE
fix: push Homebrew bin in front of /usr/bin in PATH

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -35,6 +35,7 @@ export PATH="$HOME/.npm-global/bin:$PATH"
 export PATH="$JAVA_HOME/bin:$PATH"
 export PATH="./bin:$PATH"
 export PATH="/usr/local/opt/libpq/bin:$PATH"
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 
 NPM_CONFIG_PREFIX=~/.npm-global
 


### PR DESCRIPTION
## Summary

- `python3` was resolving to Apple's stock `/usr/bin/python3` (3.9.6) instead of Homebrew's 3.14, because the cascade of `export PATH=/usr/bin:$PATH` etc. in `dot_zshrc` ended up placing `/usr/bin` at position 17 of `$PATH` and `/opt/homebrew/bin` at position 30.
- This broke any Claude Code skill that imports `tomllib` (stdlib only since Python 3.11), with errors like `Exit code 3 — Python 3.11+ is required (stdlib tomllib not found)`.
- One-line fix: append `export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"` at the end of the PATH block so Homebrew binaries take precedence — matches the official Apple Silicon Homebrew setup.

## Test plan

- [x] `chezmoi apply`
- [x] Open a new shell
- [x] `which python3` → `/opt/homebrew/bin/python3`
- [x] `python3 --version` → `Python 3.14.x`
- [x] `python3 -c "import tomllib; print('ok')"` → `ok`
- [x] Re-run the Claude skill that was failing → no more `tomllib` error