### PR TITLE
feat: 🎸 add zoxide shell integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ The `dot_dotfiles_update` script is sourced by `.zshrc` and auto-runs `chezmoi u
 
 ## Structure
 
-- `dot_zshrc` — Main shell config. Sources a curated list of alias files from `~/.aliases/` (explicit `. ~/.aliases/<name>.sh` lines — not a glob), configures NVM, rbenv, Java, PostgreSQL PATH entries, plus bun integration.
+- `dot_zshrc` — Main shell config. Sources a curated list of alias files from `~/.aliases/` (explicit `. ~/.aliases/<name>.sh` lines — not a glob), configures NVM, rbenv, Java, PostgreSQL PATH entries, plus bun integration. Shell integrations for `wt` (Worktrunk) and `zoxide` are appended at the end, each guarded by `command -v` so a fresh machine without the binary starts cleanly.
 - `dot_gitconfig` — Git settings with `includeIf gitdir:` rules pointing at per-context configs in `~/Documents/projects/<group>/.gitconfig` (currently `niji/`, `personal/`, `kering/`). Each per-context file sets identity, signing key, and (for Kering) the GitHub URL rewrite to use the `github-kering` SSH host alias.
 - `dot_aliases/` — Modular alias/function files loaded in alphabetical order. `colors.sh` and `text.sh` must load before others (they define helpers used downstream).
 - `dot_npmrcs/` — Example npm user-configs that the `npm.sh` hook can switch to. Only `*.example` files are tracked (real configs hold auth tokens and live un-tracked next to them, see "npm registry per directory").

--- a/dot_gitignore_global
+++ b/dot_gitignore_global
@@ -8,3 +8,5 @@ npm-debug.log
 Thumbs.db
 
 /tmp
+
+**/.claude/settings.local.json

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -81,6 +81,8 @@ fi
 
 if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
 
+if command -v zoxide >/dev/null 2>&1; then eval "$(zoxide init zsh)"; fi
+
 # bun completions
 [ -s "/Users/romain.laurent/.bun/_bun" ] && source "/Users/romain.laurent/.bun/_bun"
 


### PR DESCRIPTION
Adds the zoxide shell hook to `dot_zshrc`.

## What

```sh
if command -v zoxide >/dev/null 2>&1; then eval "$(zoxide init zsh)"; fi
```

The `command -v` guard mirrors the existing `wt` init line and the defensive `npm.sh` hook: a fresh machine that has not installed zoxide yet starts without errors.

Placement is deliberate — after `oh-my-zsh.sh` so `compinit` has run and completions register, and after the `~/.aliases/*.sh` sourcing so nothing shadows `z` / `zi`.

## Verified

- `z` and `zi` are defined after init; the database records visits.
- `chpwd` hooks still fire on `z`, so the `npm.sh` per-directory npm registry switch keeps working (zoxide navigates via `builtin cd`). No conflicting `z`, `zi` or `cd` alias exists in `dot_aliases/`, and the oh-my-zsh `z` plugin is not loaded.

Not applied to `$HOME` in this change — `chezmoi apply` currently prompts because `~/.zshrc` was edited out-of-band by the Antigravity CLI installer.

## Second commit

`**/.claude/settings.local.json` already existed in `~/.gitignore_global` but was absent from the chezmoi source, so any `apply` would have silently dropped it. Now tracked.

Install side: `brew install zoxide` (already present locally, 0.10.0).